### PR TITLE
improve: delete actions wf only when initialize

### DIFF
--- a/actions/src/connector/github_connector.py
+++ b/actions/src/connector/github_connector.py
@@ -57,8 +57,10 @@ class GithubConnector():
 
   def _delete_all_workflows(self, repo) -> None:
       contents = repo.get_contents(".github/workflows", ref="master")
+
       for content in contents:
-          self._delete(repo, content)
+          if "actions" in content.path:
+            self._delete(repo, content)
 
   def _delete(self, repo, content) -> None:
       try:


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
Improve `_delete_all_workflows` to delete only the workflow files of actions when the workflow is first deployed.

Related issue: https://github.com/cloudforet-io/cloudforet/issues/4

### Known issue